### PR TITLE
feat: add USE_LOCAL, write to /tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ $ MICROSCANNER_TOKEN=xxxxxxxxxxxxxxxx ./scan.sh ubuntu:16.04
 ```
 
 The script will return `0` if Microscanner passes the image, or `1` if it fails it.
+
+## Local microscanner
+
+To avoid pulling the microscanner, if it's available in the local path:
+
+```
+$ USE_LOCAL=1 MICROSCANNER_TOKEN=xxxxxxxxxxxxxxxx ./scan.sh ubuntu:16.04
+```

--- a/scan.sh
+++ b/scan.sh
@@ -22,7 +22,15 @@ main() {
   cd "${TEMP_DIR}"
 
   MICROSCANNER_SOURCE="https://get.aquasec.com/microscanner"
-  if MICROSCANNER_BINARY=$(command -v microscanner); then
+  if [[ "${USE_LOCAL:-0}" == 1 ]] \
+    && MICROSCANNER_BINARY=$(
+      {
+        unset -f microscanner
+        unalias microscanner
+      } &>/dev/null
+      { command -v microscanner 2>/dev/null || which microscanner; }
+    ); then
+
     printf "Using local "
     microscanner --version
 
@@ -55,10 +63,10 @@ fi;
 EOL
 
     cat <<EOL
-ADD ${MICROSCANNER_SOURCE} .
-RUN chmod +x microscanner \
-  && ./microscanner --version \
-  && ./microscanner ${MICROSCANNER_TOKEN}
+ADD ${MICROSCANNER_SOURCE} /tmp/microscanner
+RUN [ -x /tmp/microscanner ] || chmod +x /tmp/microscanner \
+  && /tmp/microscanner --version \
+  && /tmp/microscanner ${MICROSCANNER_TOKEN}
 EOL
 
   } | docker build -t ${TEMP_IMAGE_TAG} -f - .


### PR DESCRIPTION
- only use the local microscanner binary if set with USE_LOCAL env var
  - couldn't see a nice way to avoid polluting the `print_usage()` output, so
  only documented in the README
- add microscanner to /tmp to avoid permissions issues