### PR TITLE
Don't keep intermediate docker containers

### DIFF
--- a/scan.sh
+++ b/scan.sh
@@ -71,7 +71,7 @@ RUN [ -x /tmp/microscanner ] || chmod +x /tmp/microscanner \
   && /tmp/microscanner ${MICROSCANNER_OPTIONS} ${MICROSCANNER_TOKEN}
 EOL
 
-  } | docker build -t ${TEMP_IMAGE_TAG} -f - .
+  } | docker build --force-rm -t ${TEMP_IMAGE_TAG} -f - .
 }
 
 print_usage() {


### PR DESCRIPTION
When building a docker image, if any of the "RUN" command fails with an exit code different from zero, then the intermediate container created to run the command will be kept for later inspection.
However, when building such images in a Continuous Integration server, such as Jenkins running inside Kubernetes, this will prevent Kubernetes from doing its garbage collection of images as the containers are still locked by the docker engine.
Using the --force-rm flag will prevent this side-effect.